### PR TITLE
Bump project version to 3.1.0-SNAPSHOT and update OpenSearch dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-configsync</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin synchronizes OpenSearch configuration files across nodes, enabling consistent settings and secure, automated updates in distributed environments.</description>
 	<inceptionYear>2011</inceptionYear>
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.0.0</opensearch.version>
-		<opensearch.runner.version>3.0.0.0</opensearch.runner.version>
+		<opensearch.version>3.1.0</opensearch.version>
+		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.configsync.ConfigSyncPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<log4j.version>2.21.0</log4j.version>


### PR DESCRIPTION
This pull request updates the versioning in the `pom.xml` file to align with the latest OpenSearch release, ensuring compatibility and consistency across the project.

Version updates:

* Updated the project version from `3.0.1-SNAPSHOT` to `3.1.0-SNAPSHOT` to reflect the new development iteration. (`[pom.xmlL7-R7](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7)`)
* Updated the OpenSearch and OpenSearch Runner versions from `3.0.0` to `3.1.0` and `3.0.0.0` to `3.1.0.0`, respectively, to maintain compatibility with the latest OpenSearch release. (`[pom.xmlL39-R40](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R40)`)