### PR TITLE
Enhance README with detailed usage guide and ignore .serena directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 .vscode
 /target
+/.serena

--- a/README.md
+++ b/README.md
@@ -1,62 +1,167 @@
-OpenSearch Config Sync Plugin
+# OpenSearch Config Sync Plugin
+
 [![Java CI with Maven](https://github.com/codelibs/opensearch-configsync/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/opensearch-configsync/actions/workflows/maven.yml)
-=======================
+[![Maven Central](https://img.shields.io/maven-central/v/org.codelibs.opensearch/opensearch-configsync.svg)](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/)
 
 ## Overview
 
-Config Sync Plugin provides a feature to distribute files, such as script or dictionary file, to nodes in your cluster.
-These files are managed in .configsync index, and each node sync up with them.
+The OpenSearch Config Sync Plugin provides seamless distribution and synchronization of configuration files (such as scripts, dictionaries, or custom settings) across all nodes in your OpenSearch cluster. This plugin ensures consistent configuration management in distributed environments through automated file synchronization.
 
-## Version
+### Key Features
 
-[Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/)
+- **Distributed File Management**: Centrally manage and distribute files across all cluster nodes
+- **Automatic Synchronization**: Files are automatically synced to all nodes at configurable intervals
+- **RESTful API**: Complete REST API for file operations (upload, download, list, delete)
+- **Secure Storage**: Files are securely stored in the `.configsync` system index
+- **Cluster-wide Operations**: Flush and reset operations across the entire cluster
+- **Real-time Updates**: Changes are propagated to all nodes without manual intervention
+
+## Compatibility
+
+| Plugin Version | OpenSearch Version | Java Version |
+|---------------|--------------------|--------------|
+| 3.2.x         | 3.2.0+            | 21+          |
+
+## Version History
+
+[View all versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/)
 
 ### Issues/Questions
 
-Please file an [issue](https://github.com/codelibs/opensearch-configsync/issues "issue").
+Please file an [issue](https://github.com/codelibs/opensearch-configsync/issues) if you encounter any problems or have questions.
 
 ## Installation
 
-    $ $OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:1.2.0
+```bash
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.2.0
+```
+
+**Note**: Replace `3.2.0` with the latest version available in the [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/).
 
 ## Getting Started
 
-### Register File
+### API Endpoints
 
-    $ curl -XPOST -H 'Content-Type:application/json' localhost:9200/_configsync/file?path=user-dict.txt --data-binary @user-dict.txt
+The plugin provides RESTful API endpoints for managing configuration files:
 
-The above request is to add file info to .configsync index.
-path parameter is a synced file location under $OPENSEARCH\_CONF directory(ex. /etc/opensearch/user-dict.txt).
+#### Upload/Register File
 
-### Get File List
+Upload a file to be synchronized across all cluster nodes:
 
-Send GET request without path parameter:
+```bash
+curl -XPOST -H 'Content-Type:application/json' \
+  localhost:9200/_configsync/file?path=user-dict.txt \
+  --data-binary @user-dict.txt
+```
 
-    $ curl -XGET -H 'Content-Type:application/json' localhost:9200/_configsync/file
-    {"acknowledged":true,"path":["user-dict.txt"]}
+- **path**: Target file location under `$OPENSEARCH_CONF` directory (e.g., `/etc/opensearch/user-dict.txt`)
+- The file will be stored in the `.configsync` index and distributed to all nodes
 
-### Get File
+#### List All Files
 
-Send GET request with path parameter:
+Retrieve a list of all managed configuration files:
 
-    $ curl -XGET -H 'Content-Type:application/json' localhost:9200/_configsync/file?path=user-dict.txt
+```bash
+curl -XGET -H 'Content-Type:application/json' localhost:9200/_configsync/file
+```
 
-### Delete File
+**Response:**
+```json
+{"acknowledged":true,"path":["user-dict.txt"]}
+```
 
-Send DELETE request with path parameter:
+#### Download File
 
-    $ curl -XDELETE -H 'Content-Type:application/json' localhost:9200/_configsync/file?path=user-dict.txt
+Retrieve a specific configuration file:
 
-### Sync
+```bash
+curl -XGET -H 'Content-Type:application/json' \
+  localhost:9200/_configsync/file?path=user-dict.txt
+```
 
-Each node copies a file from .configsync index periodically if the file is updated.
-The interval time is specified by configsync.flush\_interval in /etc/elasticserch/opensearch.yml.
-The default value is 1m.
+Returns the file content as stored in the `.configsync` index.
 
-    configsync.flush_interval: 1m
+#### Delete File
 
-### Reset
+Remove a file from synchronization:
 
-To restart a scheduler for checking .configsync index, send POST request as below:
+```bash
+curl -XDELETE -H 'Content-Type:application/json' \
+  localhost:9200/_configsync/file?path=user-dict.txt
+```
 
-    $ curl -XPOST -H 'Content-Type:application/json' localhost:9200/_configsync/reset
+This removes the file from the `.configsync` index, but does not delete existing files on nodes.
+
+### Additional Operations
+
+#### Force Flush
+
+Force immediate synchronization across all nodes:
+
+```bash
+curl -XPOST -H 'Content-Type:application/json' localhost:9200/_configsync/flush
+```
+
+#### Reset Synchronization
+
+Restart the synchronization scheduler:
+
+```bash
+curl -XPOST -H 'Content-Type:application/json' localhost:9200/_configsync/reset
+```
+
+## Configuration
+
+### Automatic Synchronization
+
+Files are automatically synchronized from the `.configsync` index at regular intervals. Configure the sync interval in your OpenSearch configuration file:
+
+```yaml
+# opensearch.yml
+configsync.flush_interval: 1m  # Default: 1 minute
+```
+
+### Available Settings
+
+- `configsync.flush_interval`: Interval for automatic file synchronization (default: `1m`)
+- `configsync.file_updater.enabled`: Enable/disable the file updater (default: `true`)
+- `configsync.scroll_size`: Number of files to process in each scroll request (default: `1000`)
+- `configsync.scroll_time`: Scroll timeout for file processing (default: `1m`)
+- `configsync.config_path`: Custom path for configuration files (default: OpenSearch config directory)
+- `configsync.index`: Custom index name for storing files (default: `.configsync`)
+
+## Development
+
+### Building the Plugin
+
+```bash
+mvn package
+```
+
+The built plugin will be available in `target/releases/`.
+
+### Running Tests
+
+```bash
+# Unit tests
+mvn test
+
+# Integration tests (requires running OpenSearch on port 9201)
+scripts/test.sh
+```
+
+### Release
+
+```bash
+mvn release:prepare
+mvn release:perform
+```
+
+## License
+
+This project is licensed under the Apache Software License, Version 2.0.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+


### PR DESCRIPTION
This pull request significantly improves the documentation for the OpenSearch Config Sync Plugin by expanding and restructuring the `README.md`. The changes make the plugin's capabilities, usage, configuration, and development workflow much clearer for new and existing users.

Documentation improvements:

* Added a detailed overview of the plugin, including its purpose and key features for distributed configuration management.
* Introduced comprehensive API endpoint documentation with usage examples for file upload, listing, download, deletion, and cluster-wide operations.
* Provided compatibility information, including supported OpenSearch and Java versions, and a version history section.

Configuration and development guidance:

* Documented all available configuration settings, including sync intervals and custom paths, with example YAML configuration.
* Added instructions for building, testing, and releasing the plugin, as well as guidance for contributing to the project.