### PR TITLE
chore(deps): upgrade to OpenSearch 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-configsync</artifactId>
-	<version>3.5.1-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin synchronizes OpenSearch configuration files across nodes, enabling consistent settings and secure, automated updates in distributed environments.</description>
 	<inceptionYear>2011</inceptionYear>
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.5.0</opensearch.version>
-		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
+		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.configsync.ConfigSyncPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<log4j.version>2.25.3</log4j.version>


### PR DESCRIPTION
## Summary
Upgrade opensearch-configsync to target OpenSearch 3.6.0.

## Changes Made
- Bump project version from `3.5.1-SNAPSHOT` to `3.6.0-SNAPSHOT`
- Update `opensearch.version` from `3.5.0` to `3.6.0`
- Update `opensearch.runner.version` from `3.5.0.0` to `3.6.0.0`

## Testing
- CI build and test pipeline should pass with the updated dependencies

## Breaking Changes
- None

## Additional Notes
- Follows the same pattern as previous version upgrades (e.g., #9 for 3.5.0)