### PR TITLE
chore(deps): upgrade to OpenSearch 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The OpenSearch Config Sync Plugin provides seamless distribution and synchroniza
 
 | Plugin Version | OpenSearch Version | Java Version |
 |---------------|--------------------|--------------|
-| 3.2.x         | 3.2.0+            | 21+          |
+| 3.7.x         | 3.7.0+            | 21+          |
 
 ## Version History
 
@@ -33,10 +33,10 @@ Please file an [issue](https://github.com/codelibs/opensearch-configsync/issues)
 ## Installation
 
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.2.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.7.0
 ```
 
-**Note**: Replace `3.2.0` with the latest version available in the [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/).
+**Note**: Replace `3.7.0` with the latest version available in the [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/).
 
 ## Getting Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-configsync</artifactId>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin synchronizes OpenSearch configuration files across nodes, enabling consistent settings and secure, automated updates in distributed environments.</description>
 	<inceptionYear>2011</inceptionYear>
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.6.0</opensearch.version>
-		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
+		<opensearch.version>3.7.0</opensearch.version>
+		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.configsync.ConfigSyncPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<log4j.version>2.25.3</log4j.version>


### PR DESCRIPTION
## Summary
Upgrade the plugin to support OpenSearch 3.7.0, following the release of OpenSearch 3.7.0 and OpenSearch Runner 3.7.0.0.

## Changes Made
- Bumped project version from `3.6.1-SNAPSHOT` to `3.7.0-SNAPSHOT`
- Updated `opensearch.version` from `3.6.0` to `3.7.0`
- Updated `opensearch.runner.version` from `3.6.0.0` to `3.7.0.0`
- Updated stale version references in README.md (compatibility table and installation example were still pointing at 3.2.0)

No code changes were required — the plugin is API-compatible with OpenSearch 3.7.0 as-is.

## Testing
- `mvn -B package` builds successfully
- All 66 unit tests pass, including the `ConfigSyncPluginTest` integration tests that spin up a multi-node cluster via OpenSearch Runner 3.7.0.0

## Breaking Changes
None.

## Additional Notes
Same minimal version-bump pattern as the previous 3.6.0 upgrade (#10), plus a small README cleanup.