### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -80,6 +92,14 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>


### PR DESCRIPTION
## Summary
Release builds (`mvn release:perform`) did not produce sources and javadoc jars, so they were never attached to published artifacts. This is the same issue fixed in codelibs/opensearch-runner#20 (25c54af).

## Changes Made
- Added `maven-source-plugin` 3.3.1 with an `attach-sources` execution (`jar-no-fork` goal)
- Added an `attach-javadocs` execution (`jar` goal) to the existing `maven-javadoc-plugin` configuration

The super POM release profile that used to handle this is no longer available in current Maven versions, so the plugins must be configured explicitly.

## Testing
- Ran `mvn -B package -DskipTests` and confirmed that `opensearch-configsync-3.7.0-SNAPSHOT-sources.jar` and `opensearch-configsync-3.7.0-SNAPSHOT-javadoc.jar` are generated under `target/` alongside the main jar

## Additional Notes
- pom.xml only; no code changes