### PR TITLE
chore: update OpenSearch to 3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The OpenSearch Config Sync Plugin provides seamless distribution and synchroniza
 
 | Plugin Version | OpenSearch Version | Java Version |
 |---------------|--------------------|--------------|
+| 3.8.x         | 3.8.0+            | 21+          |
 | 3.7.x         | 3.7.0+            | 21+          |
 
 ## Version History
@@ -33,10 +34,10 @@ Please file an [issue](https://github.com/codelibs/opensearch-configsync/issues)
 ## Installation
 
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.7.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.8.0
 ```
 
-**Note**: Replace `3.7.0` with the latest version available in the [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/).
+**Note**: Replace `3.8.0` with the latest version available in the [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-configsync/).
 
 ## Getting Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-configsync</artifactId>
-	<version>3.7.1-SNAPSHOT</version>
+	<version>3.8.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin synchronizes OpenSearch configuration files across nodes, enabling consistent settings and secure, automated updates in distributed environments.</description>
 	<inceptionYear>2011</inceptionYear>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.7.0</opensearch.version>
-		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
+		<opensearch.version>3.8.0</opensearch.version>
+		<opensearch.runner.version>3.8.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.configsync.ConfigSyncPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>


### PR DESCRIPTION
## Summary

Updates the plugin for the OpenSearch 3.8.0 release.

## Changes

- Bump project version to `3.8.0-SNAPSHOT`
- `opensearch.version`: 3.7.0 -> 3.8.0
- `opensearch.runner.version`: 3.7.0.0 -> 3.8.0.0
- `log4j.version`: 2.25.3 -> 2.25.4 (matches the Log4j version used by OpenSearch 3.8.0)
- Update version references in README and add a 3.8.x row to the compatibility table

## Test plan

`mvn clean package` passes locally on JDK 21: 66 tests, 0 failures, 0 errors.
