### PR TITLE
feat(build): deploy to maven.codelibs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ dictionary changes.
 | 3.8.x          | 3.8.0+             | 21+          |
 | 3.7.x          | 3.7.0+             | 21+          |
 
-Released versions are listed on
+Released versions are listed in the
+[CodeLibs repository](https://maven.codelibs.org/release/org/codelibs/opensearch/opensearch-configsync/).
+Version 3.8.0 and earlier were published to
 [Maven Central](https://central.sonatype.com/artifact/org.codelibs.opensearch/opensearch-configsync/versions).
 
 ## Installation
 
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.8.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install https://maven.codelibs.org/release/org/codelibs/opensearch/opensearch-configsync/3.8.1/opensearch-configsync-3.8.1.zip
 ```
 
 Restart the node, then confirm that the plugin is loaded:
@@ -38,7 +40,7 @@ To install a locally built package instead:
 
 ```bash
 mvn clean package
-$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-configsync-3.8.0-SNAPSHOT.zip
+$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-configsync-3.8.1-SNAPSHOT.zip
 ```
 
 Use `opensearch-plugin remove configsync` to uninstall.

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,18 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
+		<extensions>
+			<!-- Wagon provider for the scpexe:// transport used by distributionManagement.
+			     It drives the external ssh and scp commands rather than an embedded SSH
+			     client, so key handling follows the system OpenSSH configuration. The
+			     embedded alternative, wagon-ssh, depends on com.jcraft:jsch 0.1.55, whose
+			     only key types are DSA, ECDSA, RSA and PKCS8. -->
+			<extension>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-ssh-external</artifactId>
+				<version>3.5.3</version>
+			</extension>
+		</extensions>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
@@ -139,30 +151,55 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.central</groupId>
-				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.11.0</version>
-				<extensions>true</extensions>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.3.1</version>
 				<configuration>
-					<publishingServerId>central</publishingServerId>
+					<releaseProfiles>release</releaseProfiles>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	<!-- This plugin is distributed through maven.codelibs.org instead of Maven
+	     Central. The scpexe transport comes from the wagon-ssh-external build
+	     extension declared above. -->
+	<distributionManagement>
+		<repository>
+			<id>codelibs-repo</id>
+			<name>CodeLibs Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>codelibs-snapshots</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>
@@ -177,7 +214,18 @@
 		<repository>
 			<id>codelibs.org</id>
 			<name>CodeLibs Repository</name>
-			<url>https://maven.codelibs.org/</url>
+			<url>https://maven.codelibs.org/release/</url>
+		</repository>
+		<repository>
+			<id>codelibs.org.snapshot</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>https://maven.codelibs.org/snapshot/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 	<dependencies>


### PR DESCRIPTION
## Summary

Publish this plugin through maven.codelibs.org instead of Maven Central, matching the distribution the Fess plugins already use.

## pom.xml

- Add the `wagon-ssh-external` build extension, which provides the `scpexe://` transport. It drives the external `ssh` and `scp` commands rather than an embedded SSH client, so key handling follows the system OpenSSH configuration. The embedded alternative, `wagon-ssh`, depends on `com.jcraft:jsch` 0.1.55, whose only key types are DSA, ECDSA, RSA and PKCS8.
- Add `distributionManagement` for the CodeLibs release and snapshot repositories, and resolve dependencies from them.
- Remove `central-publishing-maven-plugin`. Its `DeployLifecycleParticipant` disables `maven-deploy-plugin`, so leaving it in place would prevent deployment entirely.
- Declare `maven-release-plugin` with `releaseProfiles=release` and move `maven-gpg-plugin` into that profile. Ordinary builds no longer need a GPG key, while `release:perform` still signs the artifacts.

## README.md

Install from a URL instead of Maven coordinates. The `opensearch-plugin` installer resolves the `group:artifact:version` form against `repo1.maven.org` only, so that form no longer works for this plugin. Version 3.8.0 and earlier remain available on Maven Central.

## Verification

- `mvn clean deploy -DskipTests -DaltDeploymentRepository=...` deploys the jar, sources, javadoc and plugin zip, confirming `maven-deploy-plugin` is no longer disabled.
- `mvn help:effective-pom` shows `maven-gpg-plugin` in `build/plugins` only when `-Prelease` is given.
- `mvn test` passes.
